### PR TITLE
Bump version to 0.5.0-snapshot

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-0.1.0-snapshot
+0.5.0-snapshot


### PR DESCRIPTION
The adapter is a component of riff and should share a most-significant
version number.