### PR TITLE
Expose HTTP semantics to functions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,7 @@ google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLY
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
+google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zimw=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -162,7 +162,8 @@ func (p *proxy) invokeGrpc(writer http.ResponseWriter, request *http.Request) {
 	if status, ok := outputSignal.GetData().Headers[XHttpStatusHeader]; ok {
 		code, err := strconv.Atoi(status)
 		if err != nil {
-			writeError(writer, fmt.Errorf("Invalid status code %q", status))
+			writeError(writer, fmt.Errorf("invalid status code %q", status))
+			return
 		}
 		writer.WriteHeader(code)
 	}
@@ -171,7 +172,7 @@ func (p *proxy) invokeGrpc(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set(h, v)
 	}
 	if _, err = writer.Write(outputSignal.GetData().Payload); err != nil {
-		writeError(writer, err)
+		fmt.Printf("unable to write proxy response: %s\n", err)
 		return
 	}
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -19,15 +19,26 @@ package proxy
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/projectriff/streaming-http-adapter/pkg/rpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"strings"
-	"time"
+)
+
+var (
+	XHttpMethodHeader = http.CanonicalHeaderKey("x-http-method")
+	XHttpPathHeader   = http.CanonicalHeaderKey("x-http-path")
+	XHttpQueryHeader  = http.CanonicalHeaderKey("x-http-query")
+	XHttpProtoHeader  = http.CanonicalHeaderKey("x-http-proto")
+	XHttpStatusHeader = http.CanonicalHeaderKey("x-http-status")
 )
 
 type proxy struct {
@@ -73,6 +84,7 @@ func (p *proxy) Shutdown(ctx context.Context) error {
 }
 
 func (p *proxy) invokeGrpc(writer http.ResponseWriter, request *http.Request) {
+	// TODO relax these restriction now that we expose more http semantics to functions
 	if request.Method != http.MethodPost || request.URL.Path != "/" {
 		writer.WriteHeader(http.StatusNotImplemented)
 		return
@@ -115,11 +127,15 @@ func (p *proxy) invokeGrpc(writer http.ResponseWriter, request *http.Request) {
 		ContentType: contentType,
 		ArgIndex:    0,
 		Payload:     bytes,
-		Headers:     make(map[string]string, len(request.Header)),
+		Headers:     make(map[string]string, len(request.Header)+4),
 	}
 	for h, v := range request.Header {
 		inputFrame.Headers[h] = v[0]
 	}
+	inputFrame.Headers[XHttpMethodHeader] = request.Method
+	inputFrame.Headers[XHttpPathHeader] = request.URL.Path
+	inputFrame.Headers[XHttpQueryHeader] = request.URL.RawQuery
+	inputFrame.Headers[XHttpProtoHeader] = request.Proto
 	dataSignal := rpc.InputSignal{
 		Frame: &rpc.InputSignal_Data{
 			Data: &inputFrame,
@@ -142,6 +158,13 @@ func (p *proxy) invokeGrpc(writer http.ResponseWriter, request *http.Request) {
 	if _, err := client.Recv(); err != io.EOF {
 		writeError(writer, errors.New("expected EOF"))
 		return
+	}
+	if status, ok := outputSignal.GetData().Headers[XHttpStatusHeader]; ok {
+		code, err := strconv.Atoi(status)
+		if err != nil {
+			writeError(writer, fmt.Errorf("Invalid status code %q", status))
+		}
+		writer.WriteHeader(code)
 	}
 	writer.Header().Set("content-type", outputSignal.GetData().ContentType)
 	for h, v := range outputSignal.GetData().Headers {


### PR DESCRIPTION
HTTP mostly transfers well into a message as the header and entity
directly map over. However, elements of the request like the method,
path and version are lost. Likewise, on the response the status code is
not controllable.

While we don't want to encourage shoehorning applications inside a riff
function, there are times where control over these elements of the http
request/response are important. In particular the response status code
can have significant meaning.

We can map the elements of HTTP that are currently lost into message
headers to expose the fuller semantics to the function. Most functions
should not need to know or care about these headers.

- request method -> `x-http-method` message header
- request path -> `x-http-path` message header
- request query -> `x-http-query` message header
- request version -> `x-http-version` message header
- `x-http-status` message header -> http status code

Resolves #44