### PR TITLE
Set header values before writing header

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -159,17 +159,17 @@ func (p *proxy) invokeGrpc(writer http.ResponseWriter, request *http.Request) {
 		writeError(writer, errors.New("expected EOF"))
 		return
 	}
-	if status, ok := outputSignal.GetData().Headers[XHttpStatusHeader]; ok {
+	writer.Header().Set("content-type", outputSignal.GetData().ContentType)
+	for h, v := range outputSignal.GetData().Headers {
+		writer.Header().Set(h, v)
+	}
+	if status := writer.Header().Get(XHttpStatusHeader); status != "" {
 		code, err := strconv.Atoi(status)
 		if err != nil {
 			writeError(writer, fmt.Errorf("invalid status code %q", status))
 			return
 		}
 		writer.WriteHeader(code)
-	}
-	writer.Header().Set("content-type", outputSignal.GetData().ContentType)
-	for h, v := range outputSignal.GetData().Headers {
-		writer.Header().Set(h, v)
 	}
 	if _, err = writer.Write(outputSignal.GetData().Payload); err != nil {
 		fmt.Printf("unable to write proxy response: %s\n", err)


### PR DESCRIPTION
The header map is fixed when calling writeHeader. We need to set all
headers on the response before setting the status code. This also allows
the status code to be read from the header map as a case insensitive
value.