### PR TITLE
Send errors as JSON when the accept type is application/json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/golang/protobuf v1.4.2
+	github.com/markusthoemmes/goautoneg v0.0.0-20190713162725-c6008fefa5b1
 	github.com/stretchr/testify v1.6.1
 	google.golang.org/grpc v1.29.1
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/markusthoemmes/goautoneg v0.0.0-20190713162725-c6008fefa5b1 h1:Qhv4Ni88zV+8TY65yr2ak8xU4sblgs6aRT9RuGM5SNU=
+github.com/markusthoemmes/goautoneg v0.0.0-20190713162725-c6008fefa5b1/go.mod h1:qFhy2RoC9EWZC7fgczcBbUpzGNFfIm5//VO/gde0AbI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -105,6 +107,7 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zimw=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -184,9 +184,11 @@ type invocationError struct {
 }
 
 func writeError(writer http.ResponseWriter, err error, accept string) {
-	writeJSON := accept == "application/json"
-	if writeJSON {
-		writer.Header().Set("content-type", accept)
+	textPos := strings.Index(accept, "text/plain")
+	jsonPos := strings.Index(accept, "application/json")
+	preferJSON := jsonPos > -1 && (textPos == -1 || jsonPos < textPos)
+	if preferJSON {
+		writer.Header().Set("content-type", "application/json")
 	} else {
 		writer.Header().Set("content-type", "text/plain")
 	}
@@ -200,7 +202,7 @@ func writeError(writer http.ResponseWriter, err error, accept string) {
 		invErr = invocationError{Error: err.Error()}
 	}
 
-	if writeJSON {
+	if preferJSON {
 		bs, _ := json.Marshal(invErr)
 		_, _ = writer.Write(bs)
 	} else {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/markusthoemmes/goautoneg"
 	"github.com/projectriff/streaming-http-adapter/pkg/rpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -184,9 +185,9 @@ type invocationError struct {
 }
 
 func writeError(writer http.ResponseWriter, err error, accept string) {
-	textPos := strings.Index(accept, "text/plain")
-	jsonPos := strings.Index(accept, "application/json")
-	preferJSON := jsonPos > -1 && (textPos == -1 || jsonPos < textPos)
+	accepts := goautoneg.ParseAccept(accept)
+	preferJSON := accepts[0].Type == "application" && accepts[0].SubType == "json"
+
 	if preferJSON {
 		writer.Header().Set("content-type", "application/json")
 	} else {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -169,14 +169,14 @@ func Test_error_ordered_accept_text(t *testing.T) {
 	assert.Equal(t, "Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\n", responseRecorder.Body.String())
 }
 
-func Test_error_ordered_accept_json(t *testing.T) {
+func Test_error_weighted_accept_json(t *testing.T) {
 	contentType := "text/zglorbf"
 	errorMsg := fmt.Sprintf("Invoker: Unsupported Media Type: unsupported input #0's content-type %s", contentType)
 	riffClient, _ := mockRiffClientWithError(codes.InvalidArgument, errorMsg)
 	p := &proxy{riffClient: riffClient}
 	request, _ := http.NewRequest("POST", "/", strings.NewReader("some body"))
 	request.Header.Set("Content-Type", contentType)
-	request.Header.Set("Accept", "something/madeup, application/json; charset=utf-8, text/plain")
+	request.Header.Set("Accept", "something/madeup;q=0.5, application/json; charset=utf-8, text/plain")
 
 	responseRecorder := httptest.NewRecorder()
 	p.invokeGrpc(responseRecorder, request)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -135,6 +135,23 @@ func Test_unsupported_content_type(t *testing.T) {
 	assert.Equal(t, errorMsg+"\n", responseRecorder.Body.String())
 }
 
+func Test_unsupported_content_type_json(t *testing.T) {
+	contentType := "text/zglorbf"
+	errorMsg := fmt.Sprintf("Invoker: Unsupported Media Type: unsupported input #0's content-type %s", contentType)
+	riffClient, _ := mockRiffClientWithError(codes.InvalidArgument, errorMsg)
+	p := &proxy{riffClient: riffClient}
+	request, _ := http.NewRequest("POST", "/", strings.NewReader("some body"))
+	request.Header.Set("Content-Type", contentType)
+	request.Header.Set("Accept", "application/json")
+
+	responseRecorder := httptest.NewRecorder()
+	p.invokeGrpc(responseRecorder, request)
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, responseRecorder.Code)
+	assert.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
+	assert.Equal(t, "{\"error\":\"Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\"}", responseRecorder.Body.String())
+}
+
 func inputSignals(calls []mock.Call) []*rpc.InputSignal {
 	var inputSignals []*rpc.InputSignal
 	for _, call := range calls {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -152,6 +152,40 @@ func Test_unsupported_content_type_json(t *testing.T) {
 	assert.Equal(t, "{\"error\":\"Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\"}", responseRecorder.Body.String())
 }
 
+func Test_error_ordered_accept_text(t *testing.T) {
+	contentType := "text/zglorbf"
+	errorMsg := fmt.Sprintf("Invoker: Unsupported Media Type: unsupported input #0's content-type %s", contentType)
+	riffClient, _ := mockRiffClientWithError(codes.InvalidArgument, errorMsg)
+	p := &proxy{riffClient: riffClient}
+	request, _ := http.NewRequest("POST", "/", strings.NewReader("some body"))
+	request.Header.Set("Content-Type", contentType)
+	request.Header.Set("Accept", "text/plain, application/json")
+
+	responseRecorder := httptest.NewRecorder()
+	p.invokeGrpc(responseRecorder, request)
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, responseRecorder.Code)
+	assert.Equal(t, "text/plain", responseRecorder.Header().Get("Content-Type"))
+	assert.Equal(t, "Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\n", responseRecorder.Body.String())
+}
+
+func Test_error_ordered_accept_json(t *testing.T) {
+	contentType := "text/zglorbf"
+	errorMsg := fmt.Sprintf("Invoker: Unsupported Media Type: unsupported input #0's content-type %s", contentType)
+	riffClient, _ := mockRiffClientWithError(codes.InvalidArgument, errorMsg)
+	p := &proxy{riffClient: riffClient}
+	request, _ := http.NewRequest("POST", "/", strings.NewReader("some body"))
+	request.Header.Set("Content-Type", contentType)
+	request.Header.Set("Accept", "something/madeup, application/json; charset=utf-8, text/plain")
+
+	responseRecorder := httptest.NewRecorder()
+	p.invokeGrpc(responseRecorder, request)
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, responseRecorder.Code)
+	assert.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
+	assert.Equal(t, "{\"error\":\"Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\"}", responseRecorder.Body.String())
+}
+
 func inputSignals(calls []mock.Call) []*rpc.InputSignal {
 	var inputSignals []*rpc.InputSignal
 	for _, call := range calls {


### PR DESCRIPTION
As discussed in projectriff/node-function-invoker/issues/211, we need to be able to alway send JSON back to end-users of riff functions. In the case where an invoker throws an error, the streaming-http-adapter spits out `text/plain`. This is a first pass of the streaming-http-adapter support `application/json` as a first-class content-type.

Signed-off-by: Jesse Brown <jabrown85@gmail.com>