### PR TITLE
fix invalid accept type parsing error to support http 406 code

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -186,7 +186,7 @@ type invocationError struct {
 
 func writeError(writer http.ResponseWriter, err error, accept string) {
 	accepts := goautoneg.ParseAccept(accept)
-	var preferJSON bool
+	preferJSON := false
 	if len(accepts) != 0 {
 		preferJSON = accepts[0].Type == "application" && accepts[0].SubType == "json"
 		if preferJSON {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -195,7 +195,7 @@ func writeError(writer http.ResponseWriter, err error, accept string) {
 			writer.Header().Set("content-type", "text/plain")
 		}
 	} else {
-		writer.Header().Set("content-type", accept)
+		writer.Header().Set("content-type", "text/plain")
 	}
 
 	var invErr invocationError

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -186,12 +186,16 @@ type invocationError struct {
 
 func writeError(writer http.ResponseWriter, err error, accept string) {
 	accepts := goautoneg.ParseAccept(accept)
-	preferJSON := accepts[0].Type == "application" && accepts[0].SubType == "json"
-
-	if preferJSON {
-		writer.Header().Set("content-type", "application/json")
+	var preferJSON bool
+	if len(accepts) != 0 {
+		preferJSON := accepts[0].Type == "application" && accepts[0].SubType == "json"
+		if preferJSON {
+			writer.Header().Set("content-type", "application/json")
+		} else {
+			writer.Header().Set("content-type", "text/plain")
+		}
 	} else {
-		writer.Header().Set("content-type", "text/plain")
+		writer.Header().Set("content-type", accept)
 	}
 
 	var invErr invocationError

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -188,7 +188,7 @@ func writeError(writer http.ResponseWriter, err error, accept string) {
 	accepts := goautoneg.ParseAccept(accept)
 	var preferJSON bool
 	if len(accepts) != 0 {
-		preferJSON := accepts[0].Type == "application" && accepts[0].SubType == "json"
+		preferJSON = accepts[0].Type == "application" && accepts[0].SubType == "json"
 		if preferJSON {
 			writer.Header().Set("content-type", "application/json")
 		} else {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -149,7 +149,7 @@ func Test_unsupported_content_type_json(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnsupportedMediaType, responseRecorder.Code)
 	assert.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
-	assert.Equal(t, "Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\n", responseRecorder.Body.String())
+	assert.Equal(t, "{\"error\":\"Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\"}", responseRecorder.Body.String())
 }
 
 func Test_error_ordered_accept_text(t *testing.T) {
@@ -183,7 +183,7 @@ func Test_error_weighted_accept_json(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnsupportedMediaType, responseRecorder.Code)
 	assert.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
-	assert.Equal(t, "Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\n", responseRecorder.Body.String())
+	assert.Equal(t, "{\"error\":\"Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\"}", responseRecorder.Body.String())
 }
 
 func inputSignals(calls []mock.Call) []*rpc.InputSignal {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -149,7 +149,7 @@ func Test_unsupported_content_type_json(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnsupportedMediaType, responseRecorder.Code)
 	assert.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
-	assert.Equal(t, "{\"error\":\"Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\"}", responseRecorder.Body.String())
+	assert.Equal(t, "Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\n", responseRecorder.Body.String())
 }
 
 func Test_error_ordered_accept_text(t *testing.T) {
@@ -183,7 +183,7 @@ func Test_error_weighted_accept_json(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnsupportedMediaType, responseRecorder.Code)
 	assert.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
-	assert.Equal(t, "{\"error\":\"Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\"}", responseRecorder.Body.String())
+	assert.Equal(t, "Invoker: Unsupported Media Type: unsupported input #0's content-type text/zglorbf\n", responseRecorder.Body.String())
 }
 
 func inputSignals(calls []mock.Call) []*rpc.InputSignal {


### PR DESCRIPTION
support invalid accept type such as 'accept: abc' as http 406 status 